### PR TITLE
added shortcut for router.get

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,17 +1,21 @@
 var csInterface = new CSInterface();
 
-var loc = window.location.pathname; 
-var dir = decodeURI(loc.substring(1, loc.lastIndexOf('/'))); 
+var loc = window.location.pathname;
+var dir = decodeURI(loc.substring(1, loc.lastIndexOf('/')));
 const express = require(dir + "/node_modules/express/index.js");
+
+const endpoint = function (router, path, command) {
+  router.get(path, function(req, res) {
+      res.json({ message: 'ok.' });
+      csInterface.evalScript(command + "()");
+    });
+}
 
 var app = express();
 var port = process.env.PORT || 8081;
-var router = express.Router();  
- 
-router.get('/', function(req, res) {
-    res.json({ message: 'ok.' });   
-	csInterface.evalScript("sendNameAlert()");
-});
+var router = express.Router();
+
+endpoint(router, '/', 'sendNameAlert');
 
 app.use('/ahk', router);
 app.listen(port);


### PR DESCRIPTION
use instead of `router.get(...`
`endpoint(router, path, command);`